### PR TITLE
Bump sling-bundle-parent from 62 to 66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.sling</groupId>
         <artifactId>sling-bundle-parent</artifactId>
-        <version>62</version>
+        <version>66</version>
         <relativePath />
     </parent>
 


### PR DESCRIPTION
Updates the Apache Sling bundle parent POM version to pick up the latest dependency management, plugin versions, and build configuration improvements.

- Upgraded `sling-bundle-parent` version from `62` to `66`